### PR TITLE
Ignore the command palette view

### DIFF
--- a/BeyondCompare.py
+++ b/BeyondCompare.py
@@ -83,5 +83,5 @@ class BeyondCompareCommand(sublime_plugin.ApplicationCommand):
 
 class BeyondCompareFileListener(sublime_plugin.EventListener):
     def on_activated(self, view):
-        if view.file_name() != fileA:
+        if view.file_name() is not None and view.file_name() != fileA:
             recordActiveFile(view.file_name())


### PR DESCRIPTION
Ignore all views whose file_name results in "None" because they break the plugin's functionality, making it useless unless you use the keyboard shortcut.
