### PR TITLE
New Feature: The `beyond_compare_path` can accept a dictionary for multi-platform settings.

### DIFF
--- a/BeyondCompare.py
+++ b/BeyondCompare.py
@@ -16,8 +16,10 @@ def is_windows():
 
 
 def get_location():
-    return settings().get('beyond_compare_path')
-
+    if isinstance(settings().get('beyond_compare_path') , dict):
+        return settings().get('beyond_compare_path').get(sublime.platform(), "")
+    else:
+        return settings().get('beyond_compare_path')
 
 def plugin_loaded() -> None:
     # If we are on windows - set a custom path
@@ -28,7 +30,7 @@ def plugin_loaded() -> None:
         elif os.path.exists("%s\Beyond Compare 4\BCompare.exe" % os.environ['ProgramFiles']):
             settings().set("beyond_compare_path", "%s\Beyond Compare 4\BCompare.exe" % os.environ['ProgramFiles'])
             sublime.save_settings("BeyondCompare.sublime-settings")
-        elif os.path.exists(settings().get('beyond_compare_path')):
+        elif os.path.exists(get_location()):
             return
         else:
             sublime.error_message('Could not find Beyond Compare. Please set the path to your tool in BeyondCompare.sublime-settings.')

--- a/messages.json
+++ b/messages.json
@@ -3,5 +3,6 @@
 	"1.0.3": "messages/1.0.3.txt",
 	"2.0.0": "messages/2.0.0.txt",
 	"2.0.1": "messages/2.0.1.txt",
-	"2.0.3": "messages/2.0.3.txt"
+	"2.0.3": "messages/2.0.3.txt",
+	"2.0.4": "messages/2.0.4.txt"
 }

--- a/messages/2.0.4.txt
+++ b/messages/2.0.4.txt
@@ -1,0 +1,5 @@
+
+BeyondCompare 2.0.4
+-------------------
+
+New Feature: The `beyond_compare_path` can accept a dictionary for multi-platform settings.


### PR DESCRIPTION
Facilitate cross-platform use of the same configuration file

```JSON
{
	//Define a custom path to beyond compare
	"beyond_compare_path": {
		"osx": "/usr/local/bin/bcomp",
		"windows": "C:\\Program Files\\Beyond Compare 4\\bcomp.exe"
	}
}
```
